### PR TITLE
feat: use PostgreSQL LISTEN/NOTIFY instead of polling

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"go.dataddo.com/pgq"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"go.dataddo.com/pgq"
 )
 
 var db *pgxpool.Pool
@@ -17,7 +18,6 @@ func ExampleNewConsumer() {
 	slogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	c, err := pgq.NewConsumer(db, "queue_name", &Handler{},
 		pgq.WithLockDuration(10*time.Minute),
-		pgq.WithPollingInterval(500*time.Millisecond),
 		pgq.WithAckTimeout(5*time.Second),
 		pgq.WithMessageProcessingReserveDuration(5*time.Second),
 		pgq.WithMaxParallelMessages(42),

--- a/integtest/consumer_test.go
+++ b/integtest/consumer_test.go
@@ -51,7 +51,6 @@ func TestConsumer_Run_graceful_shutdown(t *testing.T) {
 	consumer, err := NewConsumer(db, queueName, handler,
 		WithLogger(slog.New(slog.NewTextHandler(&tbWriter{tb: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))),
 		WithLockDuration(time.Hour),
-		WithPollingInterval(time.Second),
 		WithMaxParallelMessages(1),
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
@@ -127,7 +126,6 @@ func TestConsumer_Run_FutureMessage(t *testing.T) {
 	consumer, err := NewConsumer(db, queueName, handler,
 		WithLogger(slog.New(slog.NewTextHandler(&tbWriter{tb: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))),
 		WithLockDuration(time.Hour),
-		WithPollingInterval(time.Second),
 		WithMaxParallelMessages(1),
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
@@ -200,7 +198,6 @@ func TestConsumer_Run_MetadataFilter_Equal(t *testing.T) {
 	consumer, err := NewConsumer(db, queueName, handler,
 		WithLogger(slog.New(slog.NewTextHandler(&tbWriter{tb: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))),
 		WithLockDuration(time.Hour),
-		WithPollingInterval(time.Second),
 		WithMaxParallelMessages(1),
 		WithMetadataFilter(&MetadataFilter{Key: "baz", Operation: OpEqual, Value: "quux"}),
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
@@ -274,7 +271,6 @@ func TestConsumer_Run_MetadataFilter_NotEqual(t *testing.T) {
 	consumer, err := NewConsumer(db, queueName, handler,
 		WithLogger(slog.New(slog.NewTextHandler(&tbWriter{tb: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))),
 		WithLockDuration(time.Hour),
-		WithPollingInterval(time.Second),
 		WithMaxParallelMessages(1),
 		WithMetadataFilter(&MetadataFilter{Key: "baz", Operation: OpNotEqual, Value: "quux"}),
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {

--- a/message.go
+++ b/message.go
@@ -147,3 +147,7 @@ func buildColumnListFromTags(data interface{}) ([]string, error) {
 
 	return columns, nil
 }
+
+func channelName(queueName string) string {
+	return "pgq_" + queueName
+}

--- a/publisher.go
+++ b/publisher.go
@@ -103,6 +103,12 @@ func (d *publisher) Publish(ctx context.Context, queue string, msgs ...*MessageO
 	if err := rows.Err(); err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	_, notifyErr := tx.Exec(ctx, "SELECT pg_notify($1, $2)", channelName(queue), "")
+	if notifyErr != nil {
+		return nil, errors.WithStack(notifyErr)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
Use PostgreSQL built-in asynchronous notification mechanism ([LISTEN](https://www.postgresql.org/docs/16/sql-listen.html), [NOTIFY](https://www.postgresql.org/docs/16/sql-notify.html)) to get rid of polling.