### PR TITLE
ci: remove PostgreSQL 12 from test matrix because it's EOL

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         # version must be string, otherwise it will be converted to float
         # and the trailing zero will be removed. 1.20 -> 1.2
         go-version: [ "1.22", "1.23" ]
-        postgres-version: [ 17, 16, 15, 14, 13, 12 ]
+        postgres-version: [ 17, 16, 15, 14, 13 ]
     # Ensure that all combinations of Go and Postgres versions will run
     continue-on-error: true
 


### PR DESCRIPTION
https://www.postgresql.org/support/versioning/