### PR TITLE
feat: configurable OTel tracer for Publisher and Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ You can configure the consumer by passing the optional `ConsumeOptions` when cre
 | WithInvalidMessageCallback | Handle the invalid messages which may appear in the queue. You may re-publish it to some junk queue etc.                                                                                                                                                                                |
 | WithHistoryLimit           | how far in the history you want to search for messages in the queue. Sometimes you want to ignore messages created days ago even though the are unprocessed.                                                                                                                            |
 | WithMetrics                | No problem to attach your own metrics provider (prometheus, ...) here.                                                                                                                                                                                                                  |
+| WithTracer                 | No problem to attach your own trace provider here.                                                                                                                                                                                                                                      |
 | WithMetadataFilter         | Allows to filter consumed message. At this point OpEqual and OpNotEqual are supported                                                                                                                                                                                                   |
 
 ```go
@@ -251,6 +252,7 @@ consumer, err := NewConsumer(db, queueName, handler,
 		WithPollingInterval(2 * time.Second),
 		WithMaxParallelMessages(1),
 		WithMetrics(noop.Meter{}),
+		WithTracer(otel.Tracer("pgq")),
 	)
 ```
 

--- a/otel.go
+++ b/otel.go
@@ -1,0 +1,16 @@
+package pgq
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+var (
+	keyQueueName  = attribute.Key("queue_name")
+	keyMessageID  = attribute.Key("message_id")
+	keyResolution = attribute.Key("resolution")
+
+	noopMeter  = metricnoop.NewMeterProvider().Meter("noop")
+	noopTracer = tracenoop.NewTracerProvider().Tracer("noop")
+)


### PR DESCRIPTION
Support custom OTel tracer for `Publisher` (see `NewInstrumentedPublisher(*pgxpool.Pool, trace.Tracer, ...PublisherOption)`) and `Consumer` (see `WithTracer(trace.Tracer)`) and improve observability for publisher.