### PR TITLE
feat: replace WithMetrics option with WithMeterProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ You can configure the consumer by passing the optional `ConsumeOptions` when cre
 | WithPollingInterval        | Defines the frequency of asking postgres table for the new message `[time.Duration]`.                                                                                                                                                                                                   |
 | WithInvalidMessageCallback | Handle the invalid messages which may appear in the queue. You may re-publish it to some junk queue etc.                                                                                                                                                                                |
 | WithHistoryLimit           | how far in the history you want to search for messages in the queue. Sometimes you want to ignore messages created days ago even though the are unprocessed.                                                                                                                            |
-| WithMetrics                | No problem to attach your own metrics provider (prometheus, ...) here.                                                                                                                                                                                                                  |
-| WithTracer                 | No problem to attach your own trace provider here.                                                                                                                                                                                                                                      |
+| WithMeterProvider          | No problem to attach your own OpenTelemetry meter provider here.                                                                                                                                                                                                                        |
+| WithTracerProvider         | No problem to attach your own OpenTelemetry tracer provider here.                                                                                                                                                                                                                       |
 | WithMetadataFilter         | Allows to filter consumed message. At this point OpEqual and OpNotEqual are supported                                                                                                                                                                                                   |
 
 ```go
@@ -251,8 +251,8 @@ consumer, err := NewConsumer(db, queueName, handler,
 		WithLockDuration(10 * time.Minute),
 		WithPollingInterval(2 * time.Second),
 		WithMaxParallelMessages(1),
-		WithMetrics(noop.Meter{}),
-		WithTracer(otel.Tracer("pgq")),
+		WithMeterProvider(otel.GetMeterProvider()),
+		WithTracerProvider(otel.GetTracerProvider()),
 	)
 ```
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -22,7 +22,7 @@ func ExampleNewConsumer() {
 		pgq.WithAckTimeout(5*time.Second),
 		pgq.WithMessageProcessingReserveDuration(5*time.Second),
 		pgq.WithMaxParallelMessages(42),
-		pgq.WithMetrics(noop.Meter{}),
+		pgq.WithMeterProvider(noop.NewMeterProvider()),
 		pgq.WithHistoryLimit(24*time.Hour),
 		pgq.WithLogger(slogger),
 		pgq.WithInvalidMessageCallback(func(ctx context.Context, msg pgq.InvalidMessage, err error) {

--- a/integtest/consumer_test.go
+++ b/integtest/consumer_test.go
@@ -57,7 +57,7 @@ func TestConsumer_Run_graceful_shutdown(t *testing.T) {
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
 		}),
-		WithMetrics(noop.Meter{}),
+		WithMeterProvider(noop.NewMeterProvider()),
 	)
 	require.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestConsumer_Run_FutureMessage(t *testing.T) {
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
 		}),
-		WithMetrics(noop.Meter{}),
+		WithMeterProvider(noop.NewMeterProvider()),
 	)
 	require.NoError(t, err)
 
@@ -207,7 +207,7 @@ func TestConsumer_Run_MetadataFilter_Equal(t *testing.T) {
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
 		}),
-		WithMetrics(noop.Meter{}),
+		WithMeterProvider(noop.NewMeterProvider()),
 	)
 	require.NoError(t, err)
 
@@ -281,7 +281,7 @@ func TestConsumer_Run_MetadataFilter_NotEqual(t *testing.T) {
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
 		}),
-		WithMetrics(noop.Meter{}),
+		WithMeterProvider(noop.NewMeterProvider()),
 	)
 	require.NoError(t, err)
 
@@ -350,7 +350,7 @@ func TestConsumer_Continue_After_Error(t *testing.T) {
 		WithInvalidMessageCallback(func(_ context.Context, _ InvalidMessage, err error) {
 			require.NoError(t, err)
 		}),
-		WithMetrics(noop.Meter{}),
+		WithMeterProvider(noop.NewMeterProvider()),
 	)
 	require.NoError(t, err)
 

--- a/otel.go
+++ b/otel.go
@@ -6,11 +6,16 @@ import (
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
-var (
-	keyQueueName  = attribute.Key("queue_name")
-	keyMessageID  = attribute.Key("message_id")
-	keyResolution = attribute.Key("resolution")
+const (
+	// otelScopeName is the instrumentation scope name.
+	otelScopeName = "github.com/joschi/pgq"
+)
 
-	noopMeter  = metricnoop.NewMeterProvider().Meter("noop")
-	noopTracer = tracenoop.NewTracerProvider().Tracer("noop")
+var (
+	attrQueueName  = attribute.Key("queue_name")
+	attrMessageID  = attribute.Key("message_id")
+	attrResolution = attribute.Key("resolution")
+
+	noopMeterProvider  = metricnoop.NewMeterProvider()
+	noopTracerProvider = tracenoop.NewTracerProvider()
 )


### PR DESCRIPTION
- Replace consumer options `WithMetrics(metric.Meter)` with `WithMeterProvider(metric.MeterProvider)` and `WithTracer(trace.Tracer)` with `WithTracerProvider(trace.TracerProvider)`.
- Use consistent scope name.