### PR TITLE
feat(consumer): add Shutdown method for graceful stop

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -134,18 +134,25 @@ type InvalidMessage struct {
 	Payload  json.RawMessage
 }
 
+// ErrConsumerShutdown is returned by Run when it is invoked on a Consumer
+// whose Shutdown method has already been called. A Consumer is single-use:
+// once shut down, it cannot be reused.
+var ErrConsumerShutdown = errors.New("pgq: consumer is shut down")
+
 // Consumer is the preconfigured subscriber of the write input messages
 type Consumer struct {
-	db             *pgxpool.Pool
-	queueName      string
-	cfg            consumerConfig
-	handler        MessageHandler
-	metrics        *metrics
-	sem            *semaphore.Weighted
-	tracer         trace.Tracer
-	shutdownCtx    context.Context
-	shutdownCancel context.CancelFunc
-	inflight       sync.WaitGroup
+	db                *pgxpool.Pool
+	queueName         string
+	cfg               consumerConfig
+	handler           MessageHandler
+	metrics           *metrics
+	sem               *semaphore.Weighted
+	tracer            trace.Tracer
+	shutdownCtx       context.Context
+	shutdownCancel    context.CancelFunc
+	shutdownDone      chan struct{}
+	shutdownWaitOnce  sync.Once
+	inflight          sync.WaitGroup
 }
 
 // ConsumerOption applies option to consumerConfig.
@@ -300,6 +307,7 @@ func NewConsumer(db *pgxpool.Pool, queueName string, handler MessageHandler, opt
 		tracer:         tracer,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
+		shutdownDone:   make(chan struct{}),
 	}, nil
 }
 
@@ -331,10 +339,35 @@ func prepareProcessMetrics(queueName string, meter metric.Meter) (*metrics, erro
 	}, nil
 }
 
-// Run consumes messages until the context is cancelled or Shutdown is called.
-// Run must not be called concurrently on the same Consumer, and is single-use
-// once Shutdown has been called.
+// Run consumes messages until ctx is cancelled or Shutdown is called. Run
+// must not be called concurrently on the same Consumer, and a Consumer is
+// single-use: after Shutdown returns, a subsequent Run returns
+// [ErrConsumerShutdown] without consuming any messages.
+//
+// Run returns:
+//   - nil when Shutdown caused the loop to exit
+//   - ctx.Err() when ctx was cancelled before Shutdown
+//   - [io.EOF] when [WithStopOnEmptyQueue] is set and the queue drained
+//   - [ErrConsumerShutdown] when invoked after Shutdown
+//   - a wrapped error on fatal database failures
+//
+// Run blocks until in-flight handlers finish, regardless of which signal
+// stopped the loop.
 func (c *Consumer) Run(ctx context.Context) error {
+	// Sentinel Add must happen before any work that Shutdown.Wait could race
+	// against, including verifyTable's DB round-trips. Holding +1 throughout
+	// Run keeps the counter > 0 so a concurrent Shutdown.Wait blocks until
+	// Run's defer releases it.
+	c.inflight.Add(1)
+	defer func() {
+		c.inflight.Done()
+		c.inflight.Wait() // wait for handlers to finish
+	}()
+
+	if c.shutdownCtx.Err() != nil {
+		return ErrConsumerShutdown
+	}
+
 	c.cfg.Logger.InfoContext(ctx, "starting consumption...",
 		"inputQueue", c.queueName,
 	)
@@ -348,13 +381,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 
 	pollCtx, cancelPoll := mergeCancel(ctx, c.shutdownCtx)
 	defer cancelPoll()
-	// Sentinel Add keeps the counter > 0 while Run is active so that a
-	// concurrent Shutdown.Wait cannot race the first batch's Add at counter 0.
-	c.inflight.Add(1)
-	defer func() {
-		c.inflight.Done()
-		c.inflight.Wait() // wait for handlers to finish
-	}()
+
 	for {
 		msgs, err := c.consumeMessages(pollCtx, query)
 		if err != nil {
@@ -380,6 +407,8 @@ func (c *Consumer) Run(ctx context.Context) error {
 			go func(msg *MessageIncoming) {
 				defer c.inflight.Done()
 				defer c.sem.Release(1)
+				// Handlers receive the caller's ctx, not pollCtx: Shutdown
+				// must not interrupt in-flight handlers — only stop polling.
 				c.handleMessage(ctx, msg)
 			}(msg)
 		}
@@ -391,17 +420,22 @@ func (c *Consumer) Run(ctx context.Context) error {
 // message's Deadline. The provided ctx bounds how long Shutdown waits for
 // in-flight work; if ctx expires first, Shutdown returns ctx.Err() and Run
 // still blocks on outstanding handlers via its own wait. Shutdown is safe to
-// call multiple times and concurrently. After Shutdown, Run is no longer
-// usable.
+// call multiple times and concurrently. After Shutdown, Run is single-use
+// and returns [ErrConsumerShutdown].
+//
+// Do not call Shutdown from inside a MessageHandler with an unbounded ctx:
+// the calling handler is itself counted as in-flight work, so the wait
+// would never complete. Use a deadline-bounded ctx in that case.
 func (c *Consumer) Shutdown(ctx context.Context) error {
 	c.shutdownCancel()
-	done := make(chan struct{})
-	go func() {
-		c.inflight.Wait()
-		close(done)
-	}()
+	c.shutdownWaitOnce.Do(func() {
+		go func() {
+			c.inflight.Wait()
+			close(c.shutdownDone)
+		}()
+	})
 	select {
-	case <-done:
+	case <-c.shutdownDone:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/consumer.go
+++ b/consumer.go
@@ -351,6 +351,12 @@ func prepareProcessMetrics(queueName string, meter metric.Meter) (*metrics, erro
 //   - [ErrConsumerShutdown] when invoked after Shutdown
 //   - a wrapped error on fatal database failures
 //
+// When both ctx and Shutdown are signalled, Run returns nil: Shutdown is
+// the higher-level intent (graceful drain), and a non-nil ctx.Err() here
+// would misrepresent a successful drain as a failure to callers using a
+// non-nil check to detect errors. Callers who need to observe the ctx
+// cancellation explicitly should check ctx.Err() themselves.
+//
 // Run blocks until in-flight handlers finish, regardless of which signal
 // stopped the loop.
 func (c *Consumer) Run(ctx context.Context) error {

--- a/consumer.go
+++ b/consumer.go
@@ -136,13 +136,16 @@ type InvalidMessage struct {
 
 // Consumer is the preconfigured subscriber of the write input messages
 type Consumer struct {
-	db        *pgxpool.Pool
-	queueName string
-	cfg       consumerConfig
-	handler   MessageHandler
-	metrics   *metrics
-	sem       *semaphore.Weighted
-	tracer    trace.Tracer
+	db             *pgxpool.Pool
+	queueName      string
+	cfg            consumerConfig
+	handler        MessageHandler
+	metrics        *metrics
+	sem            *semaphore.Weighted
+	tracer         trace.Tracer
+	shutdownCtx    context.Context
+	shutdownCancel context.CancelFunc
+	inflight       sync.WaitGroup
 }
 
 // ConsumerOption applies option to consumerConfig.
@@ -285,15 +288,18 @@ func NewConsumer(db *pgxpool.Pool, queueName string, handler MessageHandler, opt
 	}
 	sem := semaphore.NewWeighted(int64(config.MaxParallelMessages))
 	tracer := config.TracerProvider.Tracer(otelScopeName)
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 
 	return &Consumer{
-		db:        db,
-		queueName: queueName,
-		cfg:       config,
-		handler:   handler,
-		metrics:   processMetrics,
-		sem:       sem,
-		tracer:    tracer,
+		db:             db,
+		queueName:      queueName,
+		cfg:            config,
+		handler:        handler,
+		metrics:        processMetrics,
+		sem:            sem,
+		tracer:         tracer,
+		shutdownCtx:    shutdownCtx,
+		shutdownCancel: shutdownCancel,
 	}, nil
 }
 
@@ -325,7 +331,9 @@ func prepareProcessMetrics(queueName string, meter metric.Meter) (*metrics, erro
 	}, nil
 }
 
-// Run consumes messages until the context isn't cancelled.
+// Run consumes messages until the context is cancelled or Shutdown is called.
+// Run must not be called concurrently on the same Consumer, and is single-use
+// once Shutdown has been called.
 func (c *Consumer) Run(ctx context.Context) error {
 	c.cfg.Logger.InfoContext(ctx, "starting consumption...",
 		"inputQueue", c.queueName,
@@ -338,14 +346,24 @@ func (c *Consumer) Run(ctx context.Context) error {
 		return fmt.Errorf("generating query: %w", err)
 	}
 
-	var wg sync.WaitGroup
-	defer wg.Wait() // wait for handlers to finish
+	pollCtx, cancelPoll := mergeCancel(ctx, c.shutdownCtx)
+	defer cancelPoll()
+	// Sentinel Add keeps the counter > 0 while Run is active so that a
+	// concurrent Shutdown.Wait cannot race the first batch's Add at counter 0.
+	c.inflight.Add(1)
+	defer func() {
+		c.inflight.Done()
+		c.inflight.Wait() // wait for handlers to finish
+	}()
 	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		msgs, err := c.consumeMessages(ctx, query)
+		msgs, err := c.consumeMessages(pollCtx, query)
 		if err != nil {
+			if c.shutdownCtx.Err() != nil {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if errors.Is(err, io.EOF) {
 				return io.EOF
 			}
@@ -357,14 +375,48 @@ func (c *Consumer) Run(ctx context.Context) error {
 			)
 			continue
 		}
-		wg.Add(len(msgs))
+		c.inflight.Add(len(msgs))
 		for _, msg := range msgs {
 			go func(msg *MessageIncoming) {
-				defer wg.Done()
+				defer c.inflight.Done()
 				defer c.sem.Release(1)
 				c.handleMessage(ctx, msg)
 			}(msg)
 		}
+	}
+}
+
+// Shutdown stops polling for new messages and waits for in-flight handlers to
+// finish. Handler contexts are not cancelled — handlers run until each
+// message's Deadline. The provided ctx bounds how long Shutdown waits for
+// in-flight work; if ctx expires first, Shutdown returns ctx.Err() and Run
+// still blocks on outstanding handlers via its own wait. Shutdown is safe to
+// call multiple times and concurrently. After Shutdown, Run is no longer
+// usable.
+func (c *Consumer) Shutdown(ctx context.Context) error {
+	c.shutdownCancel()
+	done := make(chan struct{})
+	go func() {
+		c.inflight.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// mergeCancel returns a context derived from parent that is also cancelled
+// when signal is cancelled. The returned cancel func releases the AfterFunc
+// registration and cancels the merged context.
+func mergeCancel(parent, signal context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	stop := context.AfterFunc(signal, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
 	}
 }
 

--- a/example_consumer_test.go
+++ b/example_consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -65,6 +66,45 @@ func ExampleConsumer() {
 	}
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 	if err := c.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		log.Fatal("Error running consumer:", err)
+	}
+}
+
+// ExampleConsumer_Shutdown demonstrates a graceful drain on SIGINT/SIGTERM:
+// Run is started in a goroutine, and when a signal arrives Shutdown is
+// called with a bounded grace period. In-flight handlers run to their
+// per-message deadline; Run returns nil once they finish.
+func ExampleConsumer_Shutdown() {
+	config, err := pgxpool.ParseConfig("user=postgres password=postgres host=localhost port=5432 dbname=postgres")
+	if err != nil {
+		log.Fatal("Error parsing database config:", err)
+	}
+	db, err := pgxpool.NewWithConfig(context.Background(), config)
+	if err != nil {
+		log.Fatal("Error opening database:", err)
+	}
+	defer db.Close()
+	const queueName = "test_queue"
+	c, err := pgq.NewConsumer(db, queueName, &Handler{})
+	if err != nil {
+		log.Fatal("Error creating consumer:", err)
+	}
+
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- c.Run(context.Background()) }()
+
+	<-sigCtx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := c.Shutdown(shutdownCtx); err != nil {
+		log.Println("Shutdown timed out; in-flight handlers may still be running:", err)
+	}
+
+	if err := <-runErr; err != nil {
 		log.Fatal("Error running consumer:", err)
 	}
 }

--- a/integtest/consumer_test.go
+++ b/integtest/consumer_test.go
@@ -405,9 +405,11 @@ func TestConsumer_Run_Shutdown_completes_inflight(t *testing.T) {
 	require.Equal(t, 1, len(msgIDs))
 	msgID := msgIDs[0]
 
-	// Handler sleeps without watching ctx — it must complete naturally even
-	// after Shutdown is called.
+	// Handler signals it has started, then sleeps without watching ctx — it
+	// must complete naturally even after Shutdown is called.
+	handlerStarted := make(chan struct{})
 	handler := MessageHandlerFunc(func(_ context.Context, _ *MessageIncoming) (bool, error) {
+		close(handlerStarted)
 		time.Sleep(500 * time.Millisecond)
 		return MessageProcessed, nil
 	})
@@ -423,8 +425,12 @@ func TestConsumer_Run_Shutdown_completes_inflight(t *testing.T) {
 	runDone := make(chan error, 1)
 	go func() { runDone <- consumer.Run(ctx) }()
 
-	// Give the consumer time to pick up the message.
-	time.Sleep(150 * time.Millisecond)
+	// Wait for the handler to be in flight before calling Shutdown.
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not start within 5s")
+	}
 
 	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -483,8 +489,10 @@ func TestConsumer_Run_Shutdown_bounded_by_ctx(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	handlerStarted := make(chan struct{})
 	unblock := make(chan struct{})
 	handler := MessageHandlerFunc(func(_ context.Context, _ *MessageIncoming) (bool, error) {
+		close(handlerStarted)
 		<-unblock
 		return MessageProcessed, nil
 	})
@@ -500,8 +508,12 @@ func TestConsumer_Run_Shutdown_bounded_by_ctx(t *testing.T) {
 	runDone := make(chan error, 1)
 	go func() { runDone <- consumer.Run(ctx) }()
 
-	// Give the consumer time to pick up the message and enter the handler.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the handler to be in flight before calling Shutdown.
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not start within 5s")
+	}
 
 	shutdownCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()

--- a/integtest/consumer_test.go
+++ b/integtest/consumer_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/joschi/pgq/x/schema"
 )
 
-func TestConsumer_Run_graceful_shutdown(t *testing.T) {
+func TestConsumer_Run_hard_stop_via_ctx_cancel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -377,6 +377,145 @@ func TestConsumer_Continue_After_Error(t *testing.T) {
 	err = row.Scan(&msgCount)
 	require.NoError(t, err)
 	require.Equal(t, 4, msgCount)
+}
+
+func TestConsumer_Run_Shutdown_completes_inflight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	ctx := context.Background()
+
+	db := openDB(t)
+	queueName := t.Name()
+	_, _ = db.Exec(ctx, schema.GenerateDropTableQuery(queueName))
+	_, err := db.Exec(ctx, schema.GenerateCreateTableQuery(queueName))
+	t.Cleanup(func() {
+		db := openDB(t)
+		_, err := db.Exec(ctx, schema.GenerateDropTableQuery(queueName))
+		require.NoError(t, err)
+		db.Close()
+	})
+	require.NoError(t, err)
+	publisher := NewPublisher(db)
+
+	msgIDs, err := publisher.Publish(ctx, queueName,
+		&MessageOutgoing{Payload: json.RawMessage(`{"foo":"bar"}`)},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(msgIDs))
+	msgID := msgIDs[0]
+
+	// Handler sleeps without watching ctx — it must complete naturally even
+	// after Shutdown is called.
+	handler := MessageHandlerFunc(func(_ context.Context, _ *MessageIncoming) (bool, error) {
+		time.Sleep(500 * time.Millisecond)
+		return MessageProcessed, nil
+	})
+	consumer, err := NewConsumer(db, queueName, handler,
+		WithLogger(slog.New(slog.NewTextHandler(&tbWriter{tb: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))),
+		WithLockDuration(time.Hour),
+		WithPollingInterval(50*time.Millisecond),
+		WithMaxParallelMessages(1),
+		WithMeterProvider(noop.NewMeterProvider()),
+	)
+	require.NoError(t, err)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- consumer.Run(ctx) }()
+
+	// Give the consumer time to pick up the message.
+	time.Sleep(150 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, consumer.Shutdown(shutdownCtx))
+
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after Shutdown")
+	}
+
+	db.Close()
+
+	// evaluate: handler must have completed and acked the message.
+	query := fmt.Sprintf(
+		`SELECT processed_at, locked_until FROM %s WHERE id = $1`,
+		pg.QuoteIdentifier(queueName),
+	)
+	db = openDB(t)
+	t.Cleanup(func() {
+		db.Close()
+	})
+	row := db.QueryRow(ctx, query, msgID)
+	var (
+		processedAt pgtype.Timestamptz
+		lockedUntil pgtype.Timestamptz
+	)
+	err = row.Scan(&processedAt, &lockedUntil)
+	require.NoError(t, err)
+	require.Equal(t, true, processedAt.Valid)
+	require.Equal(t, false, lockedUntil.Valid)
+}
+
+func TestConsumer_Run_Shutdown_bounded_by_ctx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	ctx := context.Background()
+
+	db := openDB(t)
+	queueName := t.Name()
+	_, _ = db.Exec(ctx, schema.GenerateDropTableQuery(queueName))
+	_, err := db.Exec(ctx, schema.GenerateCreateTableQuery(queueName))
+	t.Cleanup(func() {
+		db := openDB(t)
+		_, err := db.Exec(ctx, schema.GenerateDropTableQuery(queueName))
+		require.NoError(t, err)
+		db.Close()
+	})
+	require.NoError(t, err)
+	publisher := NewPublisher(db)
+
+	_, err = publisher.Publish(ctx, queueName,
+		&MessageOutgoing{Payload: json.RawMessage(`{"foo":"bar"}`)},
+	)
+	require.NoError(t, err)
+
+	unblock := make(chan struct{})
+	handler := MessageHandlerFunc(func(_ context.Context, _ *MessageIncoming) (bool, error) {
+		<-unblock
+		return MessageProcessed, nil
+	})
+	consumer, err := NewConsumer(db, queueName, handler,
+		WithLogger(slog.New(slog.NewTextHandler(&tbWriter{tb: t}, &slog.HandlerOptions{Level: slog.LevelDebug}))),
+		WithLockDuration(time.Hour),
+		WithPollingInterval(50*time.Millisecond),
+		WithMaxParallelMessages(1),
+		WithMeterProvider(noop.NewMeterProvider()),
+	)
+	require.NoError(t, err)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- consumer.Run(ctx) }()
+
+	// Give the consumer time to pick up the message and enter the handler.
+	time.Sleep(200 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	err = consumer.Shutdown(shutdownCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Unblock the handler; Run should then return cleanly.
+	close(unblock)
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after handler unblocked")
+	}
 }
 
 func openDB(t *testing.T) *pgxpool.Pool {


### PR DESCRIPTION
## Summary

Until now the only way to stop a `Consumer` was to cancel the context passed to `Run`, which also cancelled every in-flight handler's context and interrupted message processing. This PR adds `Consumer.Shutdown(ctx)` as a separate graceful-drain signal: it stops the polling loop but leaves handler contexts uncancelled, so handlers run to their per-message `Deadline` and ack normally.

`Run`'s existing context-cancellation behavior is preserved as the hard-stop path.

## API

```go
func (c *Consumer) Shutdown(ctx context.Context) error
```

Stops polling, then waits for in-flight handlers, bounded by `ctx`. Returns `nil` on clean drain, `ctx.Err()` on timeout. Safe to call multiple times and concurrently.

`Run`'s return value gains one case:

| Trigger                            | Returns                |
| ---------------------------------- | ---------------------- |
| Caller cancels `ctx` (hard stop)   | `ctx.Err()` (unchanged) |
| `Shutdown` called (graceful)       | `nil` (new)            |
| `FiniteConsumption` + empty queue  | `io.EOF` (unchanged)   |

## Why the two signals are orthogonal

`Run` internally splits the caller's `ctx` into two roles:

1. **`pollCtx`**: derived from caller `ctx` and an internal `shutdownCtx` via `context.AfterFunc`. Drives DB polling, transactions, and semaphore acquisition. Cancellation from either source stops polling.
2. **caller's `ctx`**: passed unchanged into `handleMessage`. Handlers are cancelled only on hard stop, never on `Shutdown`.

Without that split, "stop polling" and "kill in-flight handlers" would remain the same signal, which is exactly what `Shutdown` is meant to separate.

A sentinel `inflight.Add(1)` is held for `Run`'s lifetime so the `WaitGroup` counter is always above zero while polling is active. Without it, a concurrent `Shutdown.Wait()` could race the first batch's `Add(N)` at counter 0, violating `sync.WaitGroup`'s memory-model contract. The window is narrow in practice, but the fix is two lines.

## Tests

Two new integration tests in `integtest/consumer_test.go`:

- `TestConsumer_Run_Shutdown_completes_inflight`: handler sleeps without watching `ctx`, proves it completes naturally and acks after `Shutdown` was called mid-handle.
- `TestConsumer_Run_Shutdown_bounded_by_ctx`: handler blocks indefinitely, proves `Shutdown(100ms ctx)` returns `DeadlineExceeded` and that `Run` recovers cleanly once the handler unblocks.

The existing `TestConsumer_Run_graceful_shutdown` was renamed to `TestConsumer_Run_hard_stop_via_ctx_cancel`: it always exercised the ctx-cancel path, and the new name reflects that.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)